### PR TITLE
README should be clear with respect to document.all.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ func?.(...args) // optional function or method call
 ### Base case
 If the operand at the left-hand side of the `?.` operator evaluates to undefined or null, the expression evaluates to undefined. Otherwise the targeted property access, method or function call is triggered normally.
 
-Here are basic examples, each one followed by its desugaring. (The desugaring is not exact in the sense that the LHS should be evaluated only once.)
+Here are basic examples, each one followed by its desugaring. (The desugaring is not exact in the sense that the LHS should be evaluated only once and that `document.all` should behave as an object.)
 ```js
 a?.b                          // undefined if `a` is null/undefined, `a.b` otherwise.
 a == null ? undefined : a.b


### PR DESCRIPTION
See https://github.com/tc39/proposal-nullish-coalescing/issues/42#issuecomment-513439722.

We could rewrite every `a == null` as `a === null || a === undefined`, but that's quite longwinded, and this suffices to call out an edge case that most developers can remain blissfully ignorant of.

The Nullish Coalescing README does not have this problem.