### PR TITLE
Add references for long short-circuiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ a == null ? undefined : a.b.c(++x).d
 
 Note that the check for nullity is made on `a` only. If, for example, `a` is not null, but `a.b` is null, a TypeError will be thrown when attempting to access the property `"c"` of `a.b`.
 
-This feature is implemented by, e.g., C# and CoffeeScript [TODO: provide precise references].
+This feature is implemented by, e.g., [C#](https://docs.microsoft.com/en-gb/dotnet/csharp/language-reference/operators/member-access-operators#null-conditional-operators--and-) and [CoffeeScript](https://coffeescript.org/#existential-operator).
 
 ### Stacking
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ a == null ? undefined : a.b.c(++x).d
 
 Note that the check for nullity is made on `a` only. If, for example, `a` is not null, but `a.b` is null, a TypeError will be thrown when attempting to access the property `"c"` of `a.b`.
 
-This feature is implemented by, e.g., [C#](https://docs.microsoft.com/en-gb/dotnet/csharp/language-reference/operators/member-access-operators#null-conditional-operators--and-) and [CoffeeScript](https://coffeescript.org/#existential-operator).
+This feature is implemented by, e.g., C# and CoffeeScript; see [Prior Art](https://github.com/tc39/proposal-optional-chaining#prior-art).
 
 ### Stacking
 


### PR DESCRIPTION
Replaced `[TODO: provide precise references]` with references for long short-circuiting in both C# and CoffeeScript. 

[Documentation for C# clearly describes this behavior](https://docs.microsoft.com/en-gb/dotnet/csharp/language-reference/operators/member-access-operators#null-conditional-operators--and-) : 
"... if one operation in a chain of conditional member or element access operations returns null, the rest of the chain doesn't execute."

[Documentation for CoffeeScript is a bit more vague](http://coffeescript.org/#existential-operator):
"If all of the properties exist then you’ll get the expected result, if the chain is broken, undefined is returned instead of the TypeError that would be raised otherwise."

CoffeeScript description is not exactly precise, but considering that throws stop evaluation early, I think the reference should be adequate. If needed, it can be excluded.