### PR TITLE
Editorial: Fixed typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following languages implement the operator with the same general semantics a
 * Swift: [Optional Chaining](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/OptionalChaining.html#//apple_ref/doc/uid/TP40014097-CH21-ID245) — optional property, method, or subscript call, in read and write access.
 * CoffeeScript: [Existential operator](http://coffeescript.org/#existential-operator) — existential operator variant for property accessor, function call, object construction (`new a?()`). Also applies to assignment and deletion.
 
-The following languages have a similar feature, but do not short-circuit the whole chain when it is longer than one element. This is justified by the fact that, in those languages, methods or properties might be legitimatally used on null (e.g., null.toString() == "null" in Dart):
+The following languages have a similar feature, but do not short-circuit the whole chain when it is longer than one element. This is justified by the fact that, in those languages, methods or properties might be legitimately used on null (e.g., null.toString() == "null" in Dart):
 * Kotlin: [Safe calls](https://kotlinlang.org/docs/reference/null-safety.html#safe-calls) — optional property access for read; optional property assignment for write.
 * Dart: [Conditional member access](https://dart.dev/guides/language/language-tour#other-operators) — optional property access.
 * Ruby: [Safe navigation operator](https://ruby-doc.org/core-2.6/doc/syntax/calling_methods_rdoc.html#label-Safe+navigation+operator) — Spelled as: `a&.b`
@@ -148,7 +148,7 @@ Parentheses limit the scope of short-circuiting:
 (a == null ? undefined : a.b).c
 ```
 
-That follows from the design choice of specifying the scope of short-circuiting by syntax (like the `&&` operator), rather than propagation of a Completion (like the `break` instruction) or an adhoc Reference (like an [earlier version of this proposal](https://github.com/claudepache/es-optional-chaining)). In general, syntax cannot be arbitrarly split by parentheses: for example, `({x}) = y` is not destructuring assignment, but an attempt to assign a value to an object literal.
+That follows from the design choice of specifying the scope of short-circuiting by syntax (like the `&&` operator), rather than propagation of a Completion (like the `break` instruction) or an adhoc Reference (like an [earlier version of this proposal](https://github.com/claudepache/es-optional-chaining)). In general, syntax cannot be arbitrarily split by parentheses: for example, `({x}) = y` is not destructuring assignment, but an attempt to assign a value to an object literal.
 
 Note that, whatever the semantics are, there is no practical reason to use parentheses in that position anyway.
 


### PR DESCRIPTION
I found a couple of typos in the `README`:
`legitimatally` -> `legitimately`
`arbitrarly` -> `arbitrarily`

If these changes aren't necessary, please let me know and I'll close this PR (^_^)