### PR TITLE
Editorial: fix ambiguous references to nonterminals

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -530,12 +530,12 @@ ins .hljs.hljs {
             OptionalExpression OptionalChain
         </emu-grammar>
         <emu-alg>
-          1. Let _baseExpression_ be the first child of this production (i.e., this |MemberExpression|, |CallExpression|, or |OptionalExpression|).
+          1. Let _baseExpression_ be the first child of this |OptionalExpression| (i.e., this |MemberExpression|, |CallExpression|, or |OptionalExpression|).
           1. Let _baseReference_ be ? _baseExpression_.Evaluation().
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If _baseValue_ is *undefined* or *null*, then
             1. Return *undefined*.
-          1. Let _optionalChain_ be this |OptionalChain|.
+          1. Let _optionalChain_ be |OptionalChain|.
           1. Return ? _optionalChain_.ChainEvaluation(_baseValue_, _baseReference_).
         </emu-alg>
       </emu-clause>
@@ -544,42 +544,42 @@ ins .hljs.hljs {
         <p>With parameters _baseValue_ and _baseReference_.</p>
         <emu-grammar>OptionalChain : `?.` `[` Expression `]`</emu-grammar>
         <emu-alg>
-          1. If the code matched by this production is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
+          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return ? EvaluateDynamicPropertyAccess(_baseValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` IdentifierName</emu-grammar>
         <emu-alg>
-          1. If the code matched by this production is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
+          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return ? EvaluateStaticPropertyAccess(_baseValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : `?.` Arguments</emu-grammar>
         <emu-alg>
-          1. Let _thisChain_ be this production.
+          1. Let _thisChain_ be this |OptionalChain|.
           1. Let _tailCall_ be IsInTailPosition(_thisChain_).
           1. Return ? EvaluateCall(_baseValue_, _baseReference_, |Arguments|, _tailCall_).
         </emu-alg>
         <emu-grammar>OptionalChain : OptionalChain `[` Expression `]`</emu-grammar>
         <emu-alg>
-          1. Let _optionalChain_ be this |OptionalChain|.
+          1. Let _optionalChain_ be |OptionalChain|.
           1. Let _newReference_ be ? _optionalChain_.ChainEvaluation(_baseValue_, _baseReference_).
           1. Let _newValue_ be ? GetValue(_newReference_).
-          1. If the code matched by this production is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
+          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return ? EvaluateDynamicPropertyAccess(_newValue_, |Expression|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : OptionalChain `.` IdentifierName</emu-grammar>
         <emu-alg>
-          1. Let _optionalChain_ be this |OptionalChain|.
+          1. Let _optionalChain_ be |OptionalChain|.
           1. Let _newReference_ be ? _optionalChain_.ChainEvaluation(_baseValue_, _baseReference_).
           1. Let _newValue_ be ? GetValue(_newReference_).
-          1. If the code matched by this production is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
+          1. If the code matched by this |OptionalChain| is strict mode code, let _strict_ be *true*, else let _strict_ be *false*.
           1. Return ? EvaluateStaticPropertyAccess(_newValue_, |IdentifierName|, _strict_).
         </emu-alg>
         <emu-grammar>OptionalChain : OptionalChain Arguments</emu-grammar>
         <emu-alg>
-          1. Let _optionalChain_ be this |OptionalChain|.
+          1. Let _optionalChain_ be |OptionalChain|.
           1. Let _newReference_ be ? _optionalChain_.ChainEvaluation(_baseValue_, _baseReference_).
           1. Let _newValue_ be ? GetValue(_newReference_).
-          1. Let _thisChain_ be this production.
+          1. Let _thisChain_ be this |OptionalChain|.
           1. Let _tailCall_ be IsInTailPosition(_thisChain_).
           1. Return ? EvaluateCall(_newValue_, _newReference_, |Arguments|, _tailCall_).
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -530,7 +530,7 @@ ins .hljs.hljs {
             OptionalExpression OptionalChain
         </emu-grammar>
         <emu-alg>
-          1. Let _baseExpression_ be the first child of this |OptionalExpression| (i.e., this |MemberExpression|, |CallExpression|, or |OptionalExpression|).
+          1. Let _baseExpression_ be the first child of this |OptionalExpression| (i.e., |MemberExpression|, |CallExpression|, or |OptionalExpression|).
           1. Let _baseReference_ be ? _baseExpression_.Evaluation().
           1. Let _baseValue_ be ? GetValue(_baseReference_).
           1. If _baseValue_ is *undefined* or *null*, then


### PR DESCRIPTION
In this pull request, I suggest to use "this _symbol_" to only refer "this production", and to use "_symbol_" to refer sub-components of Parse Node.
In many abstract algorithms which use same nonterminal symbols for both whole productions and sub-components in standard specification (Evaluation of [Tagged Templates](https://tc39.es/ecma262/#sec-tagged-templates-runtime-semantics-evaluation),  [Property Accessors](https://tc39.es/ecma262/#sec-property-accessors-runtime-semantics-evaluation), etc), they use "this _MemberExpression_"(or other symbol) to refer production itself. Thus, I revised all of them which makes confusions compared to existing specifications. 
<img width="563" alt="스크린샷 2019-08-20 오후 11 26 27" src="https://user-images.githubusercontent.com/8012197/63355976-fb9c8280-c3a1-11e9-9ddd-3cc8a95ffafa.png">
