### PR TITLE
It may be good to note once, that a == null is actually a === null || a …

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If the operand at the left-hand side of the `?.` operator evaluates to undefined
 Here are basic examples, each one followed by its desugaring. (The desugaring is not exact in the sense that the LHS should be evaluated only once and that `document.all` should behave as an object.)
 ```js
 a?.b                          // undefined if `a` is null/undefined, `a.b` otherwise.
-a == null ? undefined : a.b
+a == null ? undefined : a.b   // Note a == null is the same as (a === null || a === undefined)
 
 a?.[x]                        // undefined if `a` is null/undefined, `a[x]` otherwise.
 a == null ? undefined : a[x]


### PR DESCRIPTION
It may be good to note once, that `a == null` is actually the same as `a === null || a === undefined`

I just found that out reading this code and dig into it further, but I posted it on Stack Overflow to see if other users know and it seemed like 50 out of 50 users didn't know that.

So if users read   `a == null`, they might actually feel it is just comparing to `null`.  A comment appearing once can help the situation.

It is interesting that greenhorns use `==`, but as users get better, they learn to use `===` in JavaScript, and then it is more pro, if somebody start to use `a == null` to compare it to `null` or `undefined`.