### PR TITLE
fix link to Angular doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The following languages have a similar feature, but do not short-circuit the who
 
 The following languages have a similar feature. We haven’t checked whether they have significant differences in semantics with this proposal:
 * Groovy: [Safe navigation operator](http://groovy-lang.org/operators.html#_safe_navigation_operator)
-* Angular: [Safe navigation operator](https://angular.io/guide/template-syntax#safe-navigation-operator)
+* Angular: [Safe navigation operator](https://v10.angular.io/guide/template-expression-operators#the-safe-navigation-operator----and-null-property-paths) (link to archived documentation for Angular v10)
 
 ## Syntax
 


### PR DESCRIPTION
Uses a link to an archived version of their documentation (per https://github.com/angular/angular/issues/38393#issuecomment-671522621).
Supersedes #140

